### PR TITLE
Add automated testing using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: python
+install: pip install flake8
+script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics


### PR DESCRIPTION
The repo switch would need to be turned on at https://travis-ci.org/my8100/scrapydweb to enable free automated testing of all code changes.