### PR TITLE
Loosen rule for setting variables in ScheduleCheckView

### DIFF
--- a/scrapydweb/views/operations/schedule.py
+++ b/scrapydweb/views/operations/schedule.py
@@ -260,7 +260,7 @@ class ScheduleCheckView(BaseView):
                 part = re.sub(r'\s*=\s*', '=', part)
                 if '=' not in part:
                     continue
-                m_setting = re.match(r'setting=([A-Z_]{6,31}=.+)', part)  # 'EDITOR' 'DOWNLOADER_CLIENTCONTEXTFACTORY'
+                m_setting = re.match(r'setting=([^=]+=.+)', part)
                 if m_setting:
                     self.data['setting'].append(m_setting.group(1))
                     continue


### PR DESCRIPTION
In current implementation of CMD check, only builtin settings are taken into consideration. The rule of the length of setting variable name is too strict for custom settings.

Fixes #159