### PR TITLE
fix scrapyd_server order

### DIFF
--- a/scrapydweb/utils/check_app_config.py
+++ b/scrapydweb/utils/check_app_config.py
@@ -345,13 +345,7 @@ def check_scrapyd_servers(config):
         public_url = public_url.strip(' /')
         servers.append((group, ip, port, auth, public_url))
 
-    def key_func(arg):
-        _group, _ip, _port, _auth, _public_url = arg
-        parts = _ip.split('.')
-        parts = [('0' * (3 - len(part)) + part) for part in parts]
-        return [_group, '.'.join(parts), int(_port)]
-
-    servers = sorted(set(servers), key=key_func)
+    servers = sorted(set(servers))
     check_scrapyd_connectivity(servers)
 
     config['SCRAPYD_SERVERS'] = ['%s:%s' % (ip, port) for (group, ip, port, auth, public_url) in servers]


### PR DESCRIPTION
I found a problem when using scrapydweb.

## Background
I have added two **scrapye_server nodes** (10.12.17.123, 10.16.17.124), and they are running well. But when I want to add a new node (10.12.8.62), the scrapydweb timer task will raise an error:

'Traceback (most recent call last):
   File "/usr/lib64/python3.6/runpy.py", line 193, in _run_module_as_main
     "__main__", mod_spec)
   File "/usr/lib64/python3.6/runpy.py", line 85, in _run_code
     exec(code, run_globals)
   File "/usr/local/lib/python3.6/site-packages/scrapyd/runner.py", line 40, in &lt;module&gt;
     main()
   File "/usr/local/lib/python3.6/site-packages/scrapyd/runner.py", line 35, in main
     with project_environment(project):
   File "/usr/lib64/python3.6/contextlib.py", line 81, in __enter__
     return next(self.gen)
   File "/usr/local/lib/python3.6/site-packages/scrapyd/runner.py", line 16, in project_environment
     version, eggfile = eggstorage.get(project, eggversion)
   File "/usr/local/lib/python3.6/site-packages/scrapyd/eggstorage.py", line 31, in get
     return version, open(self._eggpath(project, version), \'rb\')
 FileNotFoundError: [Errno 2] No such file or directory: \'eggs/spider_project_first/2023-04-25T17_48_09.egg\' '

After trying for a while I found the reason (the error server is not mine, so I can only show you an example):
![1685034224(1)](https://github.com/my8100/scrapydweb/assets/59362976/37dc507c-e9b6-4048-a82f-2e540abb6d15)
Picture above, the **scrapy_server**--"127.0.0.1:6800" is not bind with the **node_number**--"1".
But the scrapydweb project **timer task** is bind with the **node_number**--"1", instead of the** scrapyd_server**--"127.0.0.1".
So, when my scrapydweb_settings_v10.py's content is:

SCRAPYD_SERVERS = [
   '10.12.17.123:6800',
   '10.16.17.124:6800',
]

The relation between **scrapyd_server** and **node_number** is:
"10.12.17.123"--"1"
"10.12.17.124"--"2"

When I upload an egg file to "10.12.17.123", it's timer task runs well.
But when I add a new **scrapyd_server** to the settings file:

SCRAPYD_SERVERS = [
   '10.12.17.123:6800',
   '10.16.17.124:6800',
   '10.12.8.62:6800',
]

The relation between **scrapyd_server** and **node_number** change to:
"10.12.8.62"--"1"
"10.12.17.123"--"2"
"10.12.17.124"--"3"
instead of:
"10.12.17.123"--"1"
"10.12.17.124"--"2"
"10.12.8.62"--"3"

But the timer task will start the project by **node_number** instead of **scrapyd_server**
So it will find the egg file in **node**--"1"--"10.12.8.62", instead of **server**--"10.12.17.123".

## Change Code
After look up to the code, I found you have sorted the **scrapyd_server** order when load SCRAPYD_SERVER config from file.
By don't sort the **scrapyd_server**, the timer task runs well, and the relation between **scrapyd_server** and **node_number** is just same as SCRAPYD_SERVER config file.

## Performance
I have test for 10 days, the timer task have ran 10 times, all well.