### PR TITLE
Resolved compatibility issues related to the application context for running on recent versions of SQLAlchemy and Flask.

### DIFF
--- a/scrapydweb/__init__.py
+++ b/scrapydweb/__init__.py
@@ -118,9 +118,10 @@ def handle_db(app):
     #         self.app = app
     #         if app is not None:
     #             self.init_app(app)
-    db.app = app  # https://github.com/viniciuschiele/flask-apscheduler/blob/master/examples/flask_context.py
-    db.init_app(app)  # http://flask-sqlalchemy.pocoo.org/2.3/contexts/
-    db.create_all()
+    with app.app_context():
+        db.app = app  # https://github.com/viniciuschiele/flask-apscheduler/blob/master/examples/flask_context.py
+        db.init_app(app)  # http://flask-sqlalchemy.pocoo.org/2.3/contexts/
+        db.create_all()
 
     # https://blog.miguelgrinberg.com/post/the-flask-mega-tutorial-part-vii-error-handling
     @app.teardown_request

--- a/scrapydweb/run.py
+++ b/scrapydweb/run.py
@@ -40,7 +40,7 @@ def main():
     # "scrapydweb -h" ends up here
     update_app_config(app.config, args)
     try:
-        check_app_config(app.config)
+        check_app_config(app.config, app)
     except AssertionError as err:
         logger.error("Check app config fail: ")
         sys.exit(u"\n{err}\n\nCheck and update your settings in {path}\n".format(

--- a/scrapydweb/utils/check_app_config.py
+++ b/scrapydweb/utils/check_app_config.py
@@ -35,7 +35,7 @@ SCRAPYD_SERVER_PATTERN = re.compile(r"""
                                     """, re.X)
 
 
-def check_app_config(config):
+def check_app_config(config, app):
     def check_assert(key, default, is_instance, allow_zero=True, non_empty=False, containing_type=None):
         if is_instance is int:
             if allow_zero:
@@ -110,8 +110,9 @@ def check_app_config(config):
         # Note that check_app_config() is executed multiple times in test
         if node not in jobs_table_map:
             jobs_table_map[node] = create_jobs_table(re.sub(STRICT_NAME_PATTERN, '_', scrapyd_server))
-    db.create_all(bind='jobs')
-    logger.debug("Created %s tables for JobsView", len(jobs_table_map))
+    with app.app_context():
+        db.create_all()
+        logger.debug("Created %s tables for JobsView", len(jobs_table_map))
 
     check_assert('LOCAL_SCRAPYD_LOGS_DIR', '', str)
     check_assert('LOCAL_SCRAPYD_SERVER', '', str)

--- a/scrapydweb/views/baseview.py
+++ b/scrapydweb/views/baseview.py
@@ -69,7 +69,7 @@ class BaseView(View):
             self.logger.debug('request.args of %s\n%s', request.url, self.json_dumps(request.args))
         if request.form:
             self.logger.debug('request.form from %s\n%s', request.url, self.json_dumps(request.form))
-        if request.json:
+        if request.is_json:
             self.logger.debug('request.json from %s\n%s', request.url, self.json_dumps(request.json))
         if request.files:
             self.logger.debug('request.files from %s\n\n    %s\n', request.url, request.files)

--- a/tests/test_a_factory.py
+++ b/tests/test_a_factory.py
@@ -43,7 +43,7 @@ def test_check_app_config(app, client):
 
     # ['username:password@127.0.0.1:6800', ]
     app.config['SCRAPYD_SERVERS'] = app.config['_SCRAPYD_SERVERS']
-    check_app_config(app.config)
+    check_app_config(app.config, app)
 
     strings = []
 
@@ -66,7 +66,7 @@ def test_check_app_config(app, client):
 
         # ['username:password@127.0.0.1:6800', ]
         app.config['SCRAPYD_SERVERS'] = app.config['_SCRAPYD_SERVERS']
-        check_app_config(app.config)
+        check_app_config(app.config, app)
 
         assert app.config['LOGPARSER_PID'] is None
         assert app.config['POLL_PID'] is None


### PR DESCRIPTION
Fixed an issue related to the application context, as recent versions of SQLAlchemy no longer support the bind parameter. Additionally, resolved a problem where all requests were being blocked due to a conditional statement erroneously checking for 'request.json' on non-JSON requests.

Flask==2.3.2
Flask-SQLAlchemy==3.0.5
Jinja2==3.1.2
Scrapy==2.9.0
scrapyd==1.4.2
SQLAlchemy==2.0.17
Werkzeug==2.3.6