### PR TITLE
Fix regex on jobs view based on scrapyd v1.5.0 html change

### DIFF
--- a/scrapydweb/views/dashboard/jobs.py
+++ b/scrapydweb/views/dashboard/jobs.py
@@ -96,7 +96,7 @@ class JobsView(BaseView):
 
     def dispatch_request(self, **kwargs):
         status_code, self.text = self.make_request(self.url, auth=self.AUTH, as_json=False)
-        if status_code != 200 or not re.search(r'<body><h1>Jobs</h1>', self.text):
+        if status_code != 200 or not re.search(r'<body>\s*<h1>Jobs</h1>', self.text):
             kwargs = dict(
                 node=self.node,
                 url=self.url,


### PR DESCRIPTION
### The bug

Do to this [change](https://github.com/scrapy/scrapyd/commit/3c7a0fc00a3bc62fb32836e76b446454947123fe) in v1.5.0 the regex here (https://github.com/my8100/scrapydweb/blob/8de7ede6fe317e3ef1688572c5a0e8112cc3232f/scrapydweb/views/dashboard/jobs.py#L99C9-L99C83) does not pass and therefore the jobs view results in the error: Oops! Something went wrong.

`if status_code != 200 or not re.search(r'<body><h1>Jobs</h1>', self.text):`

### Fix

Change the regex from `<body><h1>Jobs</h1>` to `<body>\s*<h1>Jobs</h1>`